### PR TITLE
Add main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.2",
   "style": "src/tachyons-display.css",
   "description": "Performance based css module.",
-  "main": "src/tachyons-display",
+  "main": "src/tachyons-display.css",
   "keywords": [
     "tachyons",
     "tachyons-css"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.2",
   "style": "src/tachyons-display.css",
   "description": "Performance based css module.",
+  "main": "src/tachyons-display",
   "keywords": [
     "tachyons",
     "tachyons-css"


### PR DESCRIPTION
having the `main` property follows npm best practices for simpler including the main file of the package.

for example, when using cssloader in webpack

``` css
/* before */
.container {
  composes: db from 'tachyons-display/src/tachyons-display.css';
}

/* after */
.container {
  composes: db from 'tachyons-display';
}
```

i'll try to do PRs for all modules, any help is appreciated... otherwise, please try to let me know rather sooner that later, if that work would be wasted, because you don't want that feature :)
